### PR TITLE
updating wording on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ address['zipCode'];
 ```
 
 Bracket notation is a bit harder to read than dot notation, so we always default
-to the latter. However, there are two main situations in which to use bracket
+to the former. However, there are two main situations in which to use bracket
 notation.
 
 #### With Nonstandard Keys


### PR DESCRIPTION
I updated the word based on the context of the paragraph and believe that you were implying that 'dot-notation' is more frequently used. Therefore I updated the word to "former". 